### PR TITLE
Fixes needed to make it work.

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -4,6 +4,6 @@
 }
 
 .fa {
-  font-family: FontAwesome;
+  font-family: FontAwesome, fontawesome-webfont;
   font-size:60;
 }

--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -79,7 +79,7 @@ export class TNSFontIconService {
       let value = cleanValue(pair[1]);
       for (let key of keys) {
         key = key.trim().slice(1).split(':before')[0];
-        this._css[this._currentName][key] = value;
+        this._css[this._currentName][key] = String.fromCharCode(parseInt(value.substring(2), 16));
         console.log(`${key}: ${value}`);
       }
     }


### PR DESCRIPTION
Fix fonticon.service.ts so that it actually creates the icon from the code.
Fix app.css so that it has the proper reference to the font on Android.

Please note you can actually move the String.fromCharCode code up into the cleanValue; the ONLY reason I didn't was I assume you still wanted to see the debug console log with the value as a unicode number.  If you move that code up then you will get squares since console doesn't know how to display that character in the default font in the console.
