### PR TITLE
Fix/mdi compatibility

### DIFF
--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -14,7 +14,7 @@ export class TNSFontIconService {
   private _paths: any; // file paths to font icon collections
   private _currentName: string; // current collection name
   private _debug: boolean = false;
-  
+
   constructor(paths: any, debug?: boolean) {
     this._paths = paths;
     this._debug = debug;
@@ -32,8 +32,8 @@ export class TNSFontIconService {
     let initCollection = () => {
       this._currentName = fontIconCollections[cnt];
       this.css[this._currentName] = {};
-    }; 
-    
+    };
+
     let loadFiles = () => {
       initCollection();
       if (cnt === fontIconCollections.length) {
@@ -46,7 +46,7 @@ export class TNSFontIconService {
       }
     };
 
-    loadFiles();         
+    loadFiles();
   }
 
   private loadFile(path: string): Promise<any> {
@@ -61,14 +61,14 @@ export class TNSFontIconService {
         resolve();
       }, (err) => {
         reject(err);
-      });  
+      });
     });
   }
 
   private mapCss(data: any): void {
     let sets = data.split('}');
     let cleanValue = (val) => {
-      let v = val.split('content:')[1].replace(/\\f/, '\\uf').trim().replace(/\"/g, '').slice(0, -1);
+      let v = val.split('content:')[1].toLowerCase().replace(/\\f/, '\\uf').trim().replace(/\"/g, '').slice(0, -1);
       return v;
     };
 
@@ -87,5 +87,5 @@ export class TNSFontIconService {
         }
       }
     }
-  }  
+  }
 }

--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -73,7 +73,7 @@ export class TNSFontIconService {
     };
 
     for (let set of sets) {
-      let pair = set.split(':before {');
+      let pair = set.replace(/ /g, '').split(':before{');
       let keyGroups = pair[0];
       let keys = keyGroups.split(',');
       if (pair[1]) {

--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -68,7 +68,7 @@ export class TNSFontIconService {
   private mapCss(data: any): void {
     let sets = data.split('}');
     let cleanValue = (val) => {
-      let v = val.split('content:')[1].toLowerCase().replace(/\\f/, '\\uf').trim().replace(/\"/g, '').slice(0, -1);
+      let v = val.split('content:')[1].toLowerCase().replace(/\\f/, '\\uf').trim().replace(/\"/g, '').replace(/;/g, '');
       return v;
     };
 


### PR DESCRIPTION
Had a few problems while trying to integrate with https://materialdesignicons.com/

Their stylesheet generates icon classes with uppercase characters, i.e.: 

`.mdi-alert:before { content: "\F026"; }`

The other fonts you use as example in this project (font awesome / ionicons) use lowercase (i.e. "\f026";) so this should make it works in both cases now.

Also I added a separate small fix that also makes it work with minified css files. Since the fonticon.service was splitting on ':before {' and not ':before{', it wasn't detecting my sets correctly (because of the extra space after the word before). It should now work in both cases.

@NathanWalker Let me know if it doesn't make sense.
