### PR TITLE
icomoon support

### DIFF
--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -68,7 +68,7 @@ export class TNSFontIconService {
   private mapCss(data: any): void {
     let sets = data.split('}');
     let cleanValue = (val) => {
-      let v = val.split('content:')[1].toLowerCase().replace(/\\f/, '\\uf').trim().replace(/\"/g, '').replace(/;/g, '');
+      let v = val.split('content:')[1].toLowerCase().replace(/\\e/, '\\ue').replace(/\\f/, '\\uf').trim().replace(/\"/g, '').replace(/;/g, '');
       return v;
     };
 


### PR DESCRIPTION
[Icomoon](https://icomoon.io/)'s font icons unicodes start with "e" not with "f" like in FontAwesome, or ionicons. But `TNSFontIconService` works only unicodes starting with "f".

@NathanWalker please merge this small fix, to be able to use Icomoon font icon set.