### PR TITLE
Livesync exception fix

### DIFF
--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -9,7 +9,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 @Injectable()
 export class TNSFontIconService {
-  public static config: boolean = false;
+  public static config: any = {};
   public static debug: boolean = false;
   public filesLoaded: BehaviorSubject<any>;
   public css: any = {}; // font icon collections containing maps of classnames to unicode

--- a/src/app/services/fonticon.service.ts
+++ b/src/app/services/fonticon.service.ts
@@ -36,8 +36,6 @@ export class TNSFontIconService {
       initCollection();
       if (cnt === fontIconCollections.length) {
         this.filesLoaded.next(this.css);
-        // clear
-        delete TNSFontIconService.config;
       } else {
         this.loadFile(TNSFontIconService.config[this._currentName]).then(() => {
           cnt++;


### PR DESCRIPTION
If you run your app with livesync then the second run will fail with an exception: 

```
JS: Unhandled Promise rejection: Error in modules/login/login/login.html:null:null caused by: Cannot convert undefined or null to object ; Zone: angular ; Task: Promise.then ; Value: Error: Error in modules/login/login/login.html:null:null caused by: Cannot convert undefined or null to object TypeError: Cannot convert undefined or null to object
JS:     at Function.keys (native)
JS:     at TNSFontIconService.loadCss (/data/data/com.cae.lsmobile/files/app/tns_modules/nativescript-ng2-fonticon/src/app/services/fonticon.service.js:23:42)
JS:     at new TNSFontIconService (/data/data/com.cae.lsmobile/files/app/tns_modules/nativescript-ng2-fonticon/src/app/services/fonticon.service.js:18:14)
JS:     at NgModuleInjector.Object.defineProperty.get (AppModule.ngfactory.js:255:81)
JS:     at NgModuleInjector.AppModuleInjector.getInternal (AppModule.ngfactory.js:387:58)
JS:     at NgModuleInjector.get (/data/data/com.cae.lsmobile/files/app/tns_modules/@angular/core/bundles/core.umd.js:7221:31)
JS:     at ElementInjector.get (/data/data/com.cae.lsmobile/files/app/tns_modules/@angular/core/bundles/core.umd.js:9303:52)
JS:     at ReflectiveInjector_._getByKeyDefault (/data/data/com.cae.lsmobile/files/app/tns_modules/@angular/core/bundles/core.umd.js:3391:28)
JS:     at ReflectiveInjector_._getByKey (/data/data/com.cae.lsmobile/files/app/tns_modules/@angular/core/bundles/core.umd.js:3357:29)
JS:     at ReflectiveInjector_.get (/data/data/com.cae.lsmobile/files/app/tns_modules/@angular/core/bundles/core.umd.js:3166:25)
JS: Error: Uncaught (in promise): Error: Error in modules/login/login/login.html:null:null caused by: Cannot convert undefined or null to object
```

This can be fixed by deleting line 40 in fonticon.service.ts.