### PR TITLE
`tns create` puts `app` under `src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then modify the css file to isolate just the icon fonts needed. [Watch this vide
 
 * Import the `TNSFontIconModule` passing a configuration with the location to the `.css` file to `forRoot`:
 
-Use the classname prefix as the `key` and the css filename as the value relative to the `app` directory.
+Use the classname prefix as the `key` and the css filename as the value relative to directory where your `main.ts` is.
 
 ```typescript
 import { TNSFontIconModule } from 'nativescript-ngx-fonticon';


### PR DESCRIPTION
If you do `tns create HelloWorld --template tns-template-blank-ng`, install your module, and specify the following:

```
    TNSFontIconModule.forRoot({
      fa: './assets/fontawesome.css'
    })
```

Parsing CSS does not work.  No error. This is because your prefix is relative to the path where `main.ts` is.  `app` folder can be moved.  Apps created with `tns create` instead need to load like this:

```
    TNSFontIconModule.forRoot({
      fa: './app/assets/fontawesome.css'
    })
```