### PR TITLE
fix: transform args should be optional

### DIFF
--- a/src/pipes/fonticon.pipe.ts
+++ b/src/pipes/fonticon.pipe.ts
@@ -13,7 +13,7 @@ export class TNSFontIconPipe implements PipeTransform, OnDestroy {
 
   constructor(private fonticon: TNSFontIconService, private _ref: ChangeDetectorRef) { }
 
-  transform(className: string, args: any[]) {
+  transform(className: string, args?: any[]) {
     if (!this._collectionName)
       this._collectionName = getCollectionName(className, args);
 


### PR DESCRIPTION
Without being marked optional, `fullTemplateTypeCheck` on the ng compiler will fail (this is `false` by default currently, but docs state it will soon be `true` by default).