### PR TITLE
Make fonticonPure pipe transform args optional

### DIFF
--- a/src/pipes/fonticon.pipe.ts
+++ b/src/pipes/fonticon.pipe.ts
@@ -58,7 +58,7 @@ export class TNSFontIconPurePipe implements PipeTransform {
 
   constructor(private fonticon: TNSFontIconService) { }
 
-  transform(className: string, args: any[]) {
+  transform(className: string, args?: any[]) {
     if (!this._collectionName)
       this._collectionName = getCollectionName(className, args);
     


### PR DESCRIPTION
Apply same fix from #55 to `fonticonPure`.