### PR TITLE
Update code for ns6 and update readme to correspond to new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@
 
 You can use icon fonts with NativeScript by combining a class with a unicode reference in the view:
 
-* css
+- css
+
 ```css
 .fa {
   font-family: FontAwesome;
 }
 ```
 
-* view
+- view
+
 ```xml
 <Label class="fa" text="\uf293"></Label>
 ```
@@ -27,7 +29,7 @@ This works but keeping up with unicodes is not fun.
 With this plugin, you can instead reference the `fonticon` by the specific classname:
 
 ```xml
-<Label class="fa" [text]="'fa-bluetooth' | fonticon"></Label> 
+<Label class="fa" [text]="'fa-bluetooth' | fonticon"></Label>
 ```
 
 ## Install
@@ -40,13 +42,13 @@ npm install nativescript-ngx-fonticon --save
 
 [FontAwesome](https://fortawesome.github.io/Font-Awesome/) will be used in the following examples but you can use any custom font icon collection.
 
-* Place font icon `.ttf` file in `app/fonts`, for example:
-  
+- Place font icon `.ttf` file in `app/fonts`, for example:
+
 ```
 app/fonts/fontawesome-webfont.ttf
 ```
 
-* Create base class in `app.css` global file, for example:
+- Create base class in `app.css` global file, for example:
 
 ```css
 .fa {
@@ -56,7 +58,7 @@ app/fonts/fontawesome-webfont.ttf
 
 **NOTE**: Android uses the name of the file for the font-family (In this case, `fontawesome-webfont`.ttf. iOS uses the actual name of the font; for example, as found [here](https://github.com/FortAwesome/Font-Awesome/blob/master/css/font-awesome.css#L8). You could rename the font filename to `FontAwesome.ttf` to use just: `font-family: FontAwesome`. You can [learn more here](http://fluentreports.com/blog/?p=176).
 
-* Copy css to `app` somewhere, for example:
+- Copy css to `app` somewhere, for example:
 
 ```
 app/assets/font-awesome.css
@@ -64,7 +66,7 @@ app/assets/font-awesome.css
 
 Then modify the css file to isolate just the icon fonts needed. [Watch this video to better understand](https://www.youtube.com/watch?v=qb2sk0XXQDw).
 
-* Import the `TNSFontIconModule` passing a configuration with the location to the `.css` file to `forRoot`:
+- Import the `TNSFontIconModule` passing a configuration with the location to the `.css` file to `forRoot`:
 
 Use the classname prefix as the `key` and the css filename as the value relative to directory where your `main.ts` is.
 
@@ -81,14 +83,14 @@ import { TNSFontIconModule } from 'nativescript-ngx-fonticon';
 	imports: [
 		NativeScriptModule,
 		TNSFontIconModule.forRoot({
-			'fa': './assets/font-awesome.css',
-			'ion': './assets/ionicons.css'
+			'fa': require('./assets/font-awesome.css'),
+			'ion': require('./assets/ionicons.css')
 		})
 	]
 })
 ```
 
-* *Optional* Configure the service with DEBUGGING on
+- _Optional_ Configure the service with DEBUGGING on
 
 When working with a new font collection, you may need to see the mapping the service provides. Passing `true` as seen below will cause the mapping to be output in the console to determine if your font collection is being setup correctly.
 
@@ -107,13 +109,13 @@ TNSFontIconService.debug = true;
 	imports: [
 		NativeScriptModule,
 		TNSFontIconModule.forRoot({
-			'fa': './assets/font-awesome.css'
+			'fa': require('./assets/font-awesome.css')
 		})
 	]
 })
 ```
 
-* Setup your component
+- Setup your component
 
 ```typescript
 import { Component } from '@angular/core';
@@ -127,19 +129,19 @@ export class DemoComponent {
 }
 ```
 
-Demo FontAwesome (iOS) |  Demo Ionicons (iOS)
--------- | ---------
-![Sample1](https://cdn.filestackcontent.com/m6JyRO1fTsCHPohoZi5I?v=0) | ![Sample2](https://cdn.filestackcontent.com/jje2pehCRCeLDC8QHBmp?v=0)
+| Demo FontAwesome (iOS)                                                | Demo Ionicons (iOS)                                                   |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| ![Sample1](https://cdn.filestackcontent.com/m6JyRO1fTsCHPohoZi5I?v=0) | ![Sample2](https://cdn.filestackcontent.com/jje2pehCRCeLDC8QHBmp?v=0) |
 
-Demo FontAwesome (Android) |  Demo Ionicons (Android)
--------- | -------
-![Sample3](https://cdn.filestackcontent.com/lNCptx2aQisOa6p27iqb?v=0) | ![Sample4](https://cdn.filestackcontent.com/2ajSF92uQDusI37fEvQA?v=0)
+| Demo FontAwesome (Android)                                            | Demo Ionicons (Android)                                               |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| ![Sample3](https://cdn.filestackcontent.com/lNCptx2aQisOa6p27iqb?v=0) | ![Sample4](https://cdn.filestackcontent.com/2ajSF92uQDusI37fEvQA?v=0) |
 
 ## How about just NativeScript without Angular?
 
 The standard NativeScript converter is here:
 
-* [nativescript-fonticon](https://github.com/NathanWalker/nativescript-fonticon)
+- [nativescript-fonticon](https://github.com/NathanWalker/nativescript-fonticon)
 
 ## Why the TNS prefixed name?
 

--- a/src/services/fonticon.service.ts
+++ b/src/services/fonticon.service.ts
@@ -77,10 +77,11 @@ export class TNSFontIconService {
           configKey
       );
     }
+    let that = this;
     return new Promise(function(resolve, reject) {
       try {
-        var cssData = this.config[configKey];
-        this.mapCss(cssData);
+        var cssData = that.config[configKey];
+        that.mapCss(cssData);
         resolve();
       } catch (e) {
         reject(e);

--- a/src/services/fonticon.service.ts
+++ b/src/services/fonticon.service.ts
@@ -1,13 +1,13 @@
 // angular
-import { Injectable, Inject, InjectionToken } from '@angular/core';
+import { Injectable, Inject, InjectionToken } from "@angular/core";
 
 // nativescript
-import { knownFolders } from 'file-system';
+import { knownFolders } from "file-system";
 
 // libs
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject } from "rxjs";
 
-export const USE_STORE = new InjectionToken('USE_STORE');
+export const USE_STORE = new InjectionToken("USE_STORE");
 
 @Injectable()
 export class TNSFontIconService {
@@ -15,8 +15,8 @@ export class TNSFontIconService {
   public filesLoaded: BehaviorSubject<any>;
   public css: any = {}; // font icon collections containing maps of classnames to unicode
   private _currentName: string; // current collection name
-  
-  constructor( @Inject(USE_STORE) private config: any) {
+
+  constructor(@Inject(USE_STORE) private config: any) {
     this.filesLoaded = new BehaviorSubject(null);
     this.loadCss();
   }
@@ -33,59 +33,121 @@ export class TNSFontIconService {
       this.css[this._currentName] = {};
     };
 
-    let loadFiles = () => {
+    let loadData = () => {
       initCollection();
       if (cnt === fontIconCollections.length) {
         this.filesLoaded.next(this.css);
       } else {
         let fonts: any = this.config;
-        this.loadFile(fonts[this._currentName]).then(() => {
+        this.loadCssData(this._currentName).then(() => {
           cnt++;
-          loadFiles();
+          loadData();
         });
       }
     };
 
-    loadFiles();
+    loadData();
+
+    // Legacy flow
+    // let loadFiles = () => {
+    //   initCollection();
+    //   if (cnt === fontIconCollections.length) {
+    //     this.filesLoaded.next(this.css);
+    //   } else {
+    //     let fonts: any = this.config;
+    //     this.loadFile(fonts[this._currentName]).then(() => {
+    //       cnt++;
+    //       loadFiles();
+    //     });
+    //   }
+    // };
   }
 
+  // In bundled NativeScript, don't try to load the file data in the plugin.
+  // Instead, initialize the config data with a key value pair where
+  // the file data is in the value, so all we need to do is parse the
+  // file data.
+  private loadCssData(configKey): Promise<any> {
+    if (TNSFontIconService.debug) {
+      console.log("----------");
+      console.log(
+        "Loading collection '" +
+          this._currentName +
+          "' from config key name: " +
+          configKey
+      );
+    }
+    return new Promise(function(resolve, reject) {
+      try {
+        var cssData = this.config[configKey];
+        this.mapCss(cssData);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  // Legacy flow for pre NS6
   private loadFile(path: string): Promise<any> {
     if (TNSFontIconService.debug) {
       console.log(`----------`);
-      console.log(`Loading collection '${this._currentName}' from file: ${path}`);
+      console.log(
+        `Loading collection '${this._currentName}' from file: ${path}`
+      );
     }
     let cssFile = knownFolders.currentApp().getFile(path);
     return new Promise((resolve, reject) => {
-      cssFile.readText().then((data: any) => {
-        this.mapCss(data);
-        resolve();
-      }, (err: any) => {
-        reject(err);
-      });
+      cssFile.readText().then(
+        (data: any) => {
+          this.mapCss(data);
+          resolve();
+        },
+        (err: any) => {
+          reject(err);
+        }
+      );
     });
   }
 
   private mapCss(data: any): void {
-    let sets = data.split('}');
+    let sets = data.split("}");
+    var mappedCss = "";
     let cleanValue = (val: string) => {
-      let v = val.split('content:')[1].toLowerCase().replace(/\\e/, '\\ue').replace(/\\f/, '\\uf').trim().replace(/\"/g, '').replace(/;/g, '');
+      let v = val
+        .split("content:")[1]
+        .toLowerCase()
+        .replace(/\\e/, "\\ue")
+        .replace(/\\f/, "\\uf")
+        .trim()
+        .replace(/\"/g, "")
+        .replace(/;/g, "");
       return v;
     };
 
     for (let set of sets) {
-      let pair = set.replace(/ /g, '').split(':before{');
+      let pair = set.replace(/ /g, "").split(":before{");
       let keyGroups = pair[0];
-      let keys = keyGroups.split(',');
+      let keys = keyGroups.split(",");
       if (pair[1]) {
         let value = cleanValue(pair[1]);
         for (let key of keys) {
-          key = key.trim().slice(1).split(':before')[0];
-          this.css[this._currentName][key] = String.fromCharCode(parseInt(value.substring(2), 16));
+          key = key
+            .trim()
+            .slice(1)
+            .split(":before")[0];
+          this.css[this._currentName][key] = String.fromCharCode(
+            parseInt(value.substring(2), 16)
+          );
           if (TNSFontIconService.debug) {
-            console.log(`${key}: ${value}`);
+            mappedCss += `${key}: ${value}\n`;
           }
         }
       }
+    }
+
+    if (TNSFontIconService.debug) {
+      console.log(`mapped css:\n${mappedCss}`);
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/NathanWalker/nativescript-ngx-fonticon/issues/60

We could also make it so that there are two separate ways of instantiating config key, value pairs to support the legacy flow (pre NS6). However, I think that this implementation will work for pre NS6 as well. 

