### PR TITLE
Fixed TypeError: data.split is not a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ import { TNSFontIconModule } from 'nativescript-ngx-fonticon';
 	imports: [
 		NativeScriptModule,
 		TNSFontIconModule.forRoot({
-			'fa': require('~/app/assets/css/fa-5.css'),
-			'ion': require('~/app/assets/css/ionicons.css')
+			'fa': require('~/app/assets/css/fa-5.css').default,
+			'ion': require('~/app/assets/css/ionicons.css').default
 			/*
 			For non webpack, assuming the assets folder is a sibling of app.module.ts:
 			'fa': require('./assets/css/fa-5.css')
@@ -127,10 +127,10 @@ TNSFontIconService.debug = true;
 	imports: [
 		NativeScriptModule,
 		TNSFontIconModule.forRoot({
-			'fa': require('~/app/assets/css/fa-5.css')
+			'fa': require('~/app/assets/css/fa-5.css').default
 			/*
 			For non webpack, assuming the assets folder is a sibling of app.module.ts:
-			'fa': require('./assets/css/fa-5.css')
+			'fa': require('./assets/css/fa-5.css').default
 			*/
 		})
 	]


### PR DESCRIPTION
When adding the below code in Angular, its throwing error. 
```

TypeError: data.split is not a function
JS:     at TNSFontIconService.mapCss (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:93:0)
JS:     at file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:68:0
JS:     at new ZoneAwarePromise (file: node_modules\@nativescript\zone-js\zone-nativescript.js:902:0)
JS:     at TNSFontIconService.loadCssData (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:65:0)
JS:     at loadData (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:32:0)
JS:     at TNSFontIconService.loadCss (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:38:0)
JS:     at new TNSFontIconService (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:13:0)
JS:     at Object.TNSFontIconService_Factory [as factory] (file: node_modules\nativescript-ngx-fonticon\__ivy_ngcc__\fesm2015\nativescript-ngx-fonticon.js:126:66)
JS:     at R3Injector.hydrate (file:///data/data/org.nativescript.mawaqif/f...
```